### PR TITLE
Fix reStructuredText docstring warnings

### DIFF
--- a/equideepdmri/layers/EquivariantPQLayer.py
+++ b/equideepdmri/layers/EquivariantPQLayer.py
@@ -121,7 +121,7 @@ class EquivariantPQLayer(nn.Module, Recomputable):
         :param kernel_selection_rule: Rule defining which angular filter orders (l_filter) to use
             for a paths form input orders l_in to output orders l_out.
             Defaults to using all possible filter orders,
-            i.e. all l_filter with  |l_in - l_out | <= l_filter <= l_in + l_out.
+            i.e. all l_filter with  \|l_in - l_out\| <= l_filter <= l_in + l_out.
             Options are:
 
             - dict with key "lmax" and int value which additionally defines a maximum l_filter.
@@ -190,7 +190,7 @@ class EquivariantPQLayer(nn.Module, Recomputable):
             
             - dict with string keys: defines some constraints which combinations to use.
               The following constraint always holds:
-              |l_p - l_q | <= l_filter <= l_p + l_q
+              \|l_p - l_q\| <= l_filter <= l_p + l_q
               Additionally constraints can be defined by the following keys in the dict:
 
               - "l_diff_to_out_max": Maximum difference between l_p and l_filter as well as l_q and l_filter.
@@ -413,7 +413,7 @@ def EquivariantPLayer(*args, **kwargs):
     :param kernel_selection_rule: Rule defining which angular filter orders (l_filter) to use
         for a paths form input orders l_in to output orders l_out.
         Defaults to using all possible filter orders,
-        i.e. all l_filter with  |l_in - l_out | <= l_filter <= l_in + l_out.
+        i.e. all l_filter with  \|l_in - l_out\| <= l_filter <= l_in + l_out.
         Options are:
 
         - dict with key "lmax" and int value which additionally defines a maximum l_filter.

--- a/equideepdmri/layers/EquivariantPQLayer.py
+++ b/equideepdmri/layers/EquivariantPQLayer.py
@@ -299,6 +299,7 @@ class EquivariantPQLayer(nn.Module, Recomputable):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Applies the layer to input feature map x.
+
         :param x: Input feature map. Dim (N x dim_in x [Q_in] x P_z x P_y x P_x) with
             - N: batch size
             - dim_in: size of the spherical tensor at each point of the input feature map.

--- a/equideepdmri/layers/EquivariantPQLayer.py
+++ b/equideepdmri/layers/EquivariantPQLayer.py
@@ -59,25 +59,27 @@ class EquivariantPQLayer(nn.Module, Recomputable):
             For all orders corresponding to out-of-range indices the number of channels is 0.
         :param kernel_definition: Which filter basis to use in this layer.
             Valid options are:
+            
             - "p_space": to use the p-space filter basis
-                using only p-space coordinate offsets in the angular and radial part.
+              using only p-space coordinate offsets in the angular and radial part.
             - "q_space": to use the q-space filter basis
-                using only q-space coordinate offsets in the angular part
-                and q-space coordinates from input and output in the radial part.
+              using only q-space coordinate offsets in the angular part
+              and q-space coordinates from input and output in the radial part.
             - "pq_diff": to use the pq-diff filter basis
-                using difference between p- and q-space coordinate offsets in the angular part
-                and p-space coordinate offsets, q-space coordinates from input and output in the radial part.
+              using difference between p- and q-space coordinate offsets in the angular part
+              and p-space coordinate offsets, q-space coordinates from input and output in the radial part.
             - "pq_TP": to use the TP (tensor product) filter basis
-                using the tensor product of the p- and q-space filters in the angular part
-                and p-space coordinate offsets, q-space coordinates from input and output in the radial part.
+              using the tensor product of the p- and q-space filters in the angular part
+              and p-space coordinate offsets, q-space coordinates from input and output in the radial part.
             - "sum(<filters>)": where <filters> is a ";"-separated list (without spaces) of valid options for kernel_definition,
-                e.g. "sum(pq_diff;p_space)" or "sum(pq_diff;q_space)". This uses the sum of the named basis filters.
+              e.g. "sum(pq_diff;p_space)" or "sum(pq_diff;q_space)". This uses the sum of the named basis filters.
             - "concat(<filters>)" where <filters> is a ";"-separated list (without spaces) of strings "<output_channels>:<filter_type>"
-                where <output_channels> lists the channels of each order where the named filter is to be used
-                (e.g. "[3, 4]" to use it for 3 scalar and 4 vector output channelw) and
-                <filter_type> names a valid kernel_definition to use for these output channels.
-                The number of all concatenated channels needs to math type_out.
-                Example: "concat([3,4]:pq_diff,[5,2,1]:p_space)" which would require type_out = [8,6,1]
+              where <output_channels> lists the channels of each order where the named filter is to be used
+              (e.g. "[3, 4]" to use it for 3 scalar and 4 vector output channelw) and
+              <filter_type> names a valid kernel_definition to use for these output channels.
+              The number of all concatenated channels needs to math type_out.
+              Example: "concat([3,4]:pq_diff,[5,2,1]:p_space)" which would require type_out = [8,6,1]
+
         :param p_kernel_size: Size of the kernel in p-space.
             Note that the kernel always covers the whole q-space (as it is not translationally equivariant),
             so there is no q_kernel_size.
@@ -121,10 +123,12 @@ class EquivariantPQLayer(nn.Module, Recomputable):
             Defaults to using all possible filter orders,
             i.e. all l_filter with  |l_in - l_out | <= l_filter <= l_in + l_out.
             Options are:
+
             - dict with key "lmax" and int value which additionally defines a maximum l_filter.
             - dict with int-pairs as keys and list of ints as values that defines
-                for each pair of l_in and l_out the list of l_filter to use.
-                E.g. {(0,0): [0], (1,1): [0,1], (0,1): [1]}
+              for each pair of l_in and l_out the list of l_filter to use.
+              E.g. {(0,0): [0], (1,1): [0,1], (0,1): [1]}
+
         :param use_linear_model_for_zero_length: Whether to use a linear point-wise model instead of the normal kernel
             for zero lengths in the radial filter basis (default is True).
             See zero_length_eps which defines which lengths are treated as zeros.
@@ -137,12 +141,14 @@ class EquivariantPQLayer(nn.Module, Recomputable):
             Note that this parameter is ignored if there is no basis filter using p-space.
         :param p_radial_basis_params: A (optional) dict of additional parameters for the radial basis function used for p-space.
             Valid keys in this dict are:
+            
             - num_layers: Number of layers in the FC applied to the radial basis function.
-                If num_layers = 0 (default) then no FC is applied to the radial basis function.
+              If num_layers = 0 (default) then no FC is applied to the radial basis function.
             - num_units: Number of units (neurons) in each of the layer in the FC applied to the radial basis function.
-                No default, this parameter is required and must be >0 if num_layers > 0.
+              No default, this parameter is required and must be >0 if num_layers > 0.
             - activation_function: activation function used in the FC applied to the radial basis function,
-                valid are "relu" (default) or "swish"
+              valid are "relu" (default) or "swish"
+            
             Note that this parameter is ignored if there is no basis filter using p-space.
         :param q_radial_basis_type: The radial basis function type used for q-space (q-in and q-out).
             Valid options are "gaussian" (default), "cosine", "bessel".
@@ -155,12 +161,14 @@ class EquivariantPQLayer(nn.Module, Recomputable):
             Defaults to q_radial_basis_type.
         :param q_radial_basis_params: A (optional) dict of additional parameters for the radial basis function used for q-space.
             Valid keys in this dict are:
+            
             - num_layers: Number of layers in the FC applied to the radial basis function.
-                If num_layers = 0 (default) then no FC is applied to the radial basis function.
+              If num_layers = 0 (default) then no FC is applied to the radial basis function.
             - num_units: Number of units (neurons) in each of the layer in the FC applied to the radial basis function.
-                No default, this parameter is required and must be >0 if num_layers > 0.
+              No default, this parameter is required and must be >0 if num_layers > 0.
             - activation_function: activation function used in the FC applied to the radial basis function,
-                valid are "relu" (default) or "swish"
+              valid are "relu" (default) or "swish"
+                
             Note that this parameter is ignored if there is no basis filter using q-space.
         :param q_out_radial_basis_params: A dict of additional parameters for the radial basis function used for q-out (q-space of output feature map).
             See q_radial_basis_params but only for q-out.
@@ -179,17 +187,21 @@ class EquivariantPQLayer(nn.Module, Recomputable):
             Rule defining for the TP filter which pairs of l_p and l_q to use for each l_filter.
             Defaults to "TP\pm 1".
             Options are:
+            
             - dict with string keys: defines some constraints which combinations to use.
-                The following constraint always holds:
-                |l_p - l_q | <= l_filter <= l_p + l_q
-                Additionally constraints can be defined by the following keys in the dict:
-                - "l_diff_to_out_max": Maximum difference between l_p and l_filter as well as l_q and l_filter.
-                    Default to 1 (as in "TP\pm 1")
-                - "l_max" (optional): Maximum value for l_p and l_q.
-                - "l_in_diff_max" (optional): Maximum difference between l_p and l_q.
+              The following constraint always holds:
+              |l_p - l_q | <= l_filter <= l_p + l_q
+              Additionally constraints can be defined by the following keys in the dict:
+
+              - "l_diff_to_out_max": Maximum difference between l_p and l_filter as well as l_q and l_filter.
+                Default to 1 (as in "TP\pm 1")
+              - "l_max" (optional): Maximum value for l_p and l_q.
+              - "l_in_diff_max" (optional): Maximum difference between l_p and l_q.
+
             - dict with ints as keys and list of int-pairs as values that defines
-                for each l_filter the used pairs of l_p and l_q.
-                E.g. {0: [(0, 0), (1, 1)], 1: [(0, 1), (1, 0), (1, 1)]}
+              for each l_filter the used pairs of l_p and l_q.
+              E.g. {0: [(0, 0), (1, 1)], 1: [(0, 1), (1, 0), (1, 1)]}
+                
             Note that this parameter is ignored if no TP-filter basis is used.
         :param normalization: The normalization used for the spherical harmonics and the tensor product.
             Valid values are "component" (default) or "norm".
@@ -301,18 +313,21 @@ class EquivariantPQLayer(nn.Module, Recomputable):
         Applies the layer to input feature map x.
 
         :param x: Input feature map. Dim (N x dim_in x [Q_in] x P_z x P_y x P_x) with
+        
             - N: batch size
             - dim_in: size of the spherical tensor at each point of the input feature map.
             - Q_in: size of the input q-space sampling schema.
-                Optional: if no q_sampling_schema_in is specified (not None), the input is assumed to have only p-space but no q-space.
+              Optional: if no q_sampling_schema_in is specified (not None), the input is assumed to have only p-space but no q-space.
             - P_z, P_y, P_x: p-space size.
+
         :return: The output feature map. Dim (N x dim_out x [Q_out] x P_z_out x P_y_out x P_x_out) with
+
             - N: batch size
             - dim_out: size of the spherical tensor at each point of the output feature map.
             - Q_out: size of the output q-space sampling schema.
-                Optional: if no q_sampling_schema_out is specified (not None), the output has only p-space but no q-space.
+              Optional: if no q_sampling_schema_out is specified (not None), the output has only p-space but no q-space.
             - P_z_out, P_y_out, P_x_out: p-space size of the output feature map.
-                Depends on P_z, P_y, P_x, p_kernel_size, p_padding, p_stride, and p_dilation.
+              Depends on P_z, P_y, P_x, p_kernel_size, p_padding, p_stride, and p_dilation.
         """
         assert isinstance(x, torch.Tensor)
         if self.has_Q_in:
@@ -400,10 +415,12 @@ def EquivariantPLayer(*args, **kwargs):
         Defaults to using all possible filter orders,
         i.e. all l_filter with  |l_in - l_out | <= l_filter <= l_in + l_out.
         Options are:
+
         - dict with key "lmax" and int value which additionally defines a maximum l_filter.
         - dict with int-pairs as keys and list of ints as values that defines
-            for each pair of l_in and l_out the list of l_filter to use.
-            E.g. {(0,0): [0], (1,1): [0,1], (0,1): [1]}
+          for each pair of l_in and l_out the list of l_filter to use.
+          E.g. {(0,0): [0], (1,1): [0,1], (0,1): [1]}
+
     :param use_linear_model_for_zero_length: Whether to use a linear point-wise model instead of the normal kernel
         for zero lengths in the radial filter basis (default is True).
         See zero_length_eps which defines which lengths are treated as zeros.
@@ -415,12 +432,14 @@ def EquivariantPLayer(*args, **kwargs):
         Valid options are "gaussian" (default), "cosine", "bessel".
     :param p_radial_basis_params: A (optional) dict of additional parameters for the radial basis function used for p-space.
         Valid keys in this dict are:
+
         - num_layers: Number of layers in the FC applied to the radial basis function.
-            If num_layers = 0 (default) then no FC is applied to the radial basis function.
+          If num_layers = 0 (default) then no FC is applied to the radial basis function.
         - num_units: Number of units (neurons) in each of the layer in the FC applied to the radial basis function.
-            No default, this parameter is required and must be >0 if num_layers > 0.
+          No default, this parameter is required and must be >0 if num_layers > 0.
         - activation_function: activation function used in the FC applied to the radial basis function,
-            valid are "relu" (default) or "swish"
+          valid are "relu" (default) or "swish"
+
     :param normalization: The normalization used for the spherical harmonics and the tensor product.
         Valid values are "component" (default) or "norm".
     """

--- a/equideepdmri/layers/EquivariantPQLayer.py
+++ b/equideepdmri/layers/EquivariantPQLayer.py
@@ -116,7 +116,7 @@ class EquivariantPQLayer(nn.Module, Recomputable):
             If true, the vectors in the output sampling schema are normalized to lengths between 0 and 1.
             If the output sampling schema only contains a single 0-vector, no normalization is applied.
         :param scalar_bias: Whether to use a learned bias for each scalar (order 0) output channel.
-        :param: kernel_selection_rule: Rule defining which angular filter orders (l_filter) to use
+        :param kernel_selection_rule: Rule defining which angular filter orders (l_filter) to use
             for a paths form input orders l_in to output orders l_out.
             Defaults to using all possible filter orders,
             i.e. all l_filter with  |l_in - l_out | <= l_filter <= l_in + l_out.
@@ -125,11 +125,11 @@ class EquivariantPQLayer(nn.Module, Recomputable):
             - dict with int-pairs as keys and list of ints as values that defines
                 for each pair of l_in and l_out the list of l_filter to use.
                 E.g. {(0,0): [0], (1,1): [0,1], (0,1): [1]}
-        :param: use_linear_model_for_zero_length: Whether to use a linear point-wise model instead of the normal kernel
+        :param use_linear_model_for_zero_length: Whether to use a linear point-wise model instead of the normal kernel
             for zero lengths in the radial filter basis (default is True).
             See zero_length_eps which defines which lengths are treated as zeros.
             This options is useful as for small lengths the angular basis might get very inaccurate.
-        :param: zero_length_eps: The epsilon value for treating lengths as zero (see use_linear_model_for_zero_length).
+        :param zero_length_eps: The epsilon value for treating lengths as zero (see use_linear_model_for_zero_length).
             A length is treated as zero if length < zero_length_eps.
             Only relevant if use_linear_model_for_zero_length is True.
         :param p_radial_basis_type: The radial basis function type used for p-space.
@@ -394,7 +394,7 @@ def EquivariantPLayer(*args, **kwargs):
         If this parameter is set to false, it is not recomputed and the method recompute() needs to be called
         explicitly after parameters of this nn.Module have been updated.
     :param scalar_bias: Whether to use a learned bias for each scalar (order 0) output channel.
-    :param: kernel_selection_rule: Rule defining which angular filter orders (l_filter) to use
+    :param kernel_selection_rule: Rule defining which angular filter orders (l_filter) to use
         for a paths form input orders l_in to output orders l_out.
         Defaults to using all possible filter orders,
         i.e. all l_filter with  |l_in - l_out | <= l_filter <= l_in + l_out.
@@ -403,11 +403,11 @@ def EquivariantPLayer(*args, **kwargs):
         - dict with int-pairs as keys and list of ints as values that defines
             for each pair of l_in and l_out the list of l_filter to use.
             E.g. {(0,0): [0], (1,1): [0,1], (0,1): [1]}
-    :param: use_linear_model_for_zero_length: Whether to use a linear point-wise model instead of the normal kernel
+    :param use_linear_model_for_zero_length: Whether to use a linear point-wise model instead of the normal kernel
         for zero lengths in the radial filter basis (default is True).
         See zero_length_eps which defines which lengths are treated as zeros.
         This options is useful as for small lengths the angular basis might get very inaccurate.
-    :param: zero_length_eps: The epsilon value for treating lengths as zero (see use_linear_model_for_zero_length).
+    :param zero_length_eps: The epsilon value for treating lengths as zero (see use_linear_model_for_zero_length).
         A length is treated as zero if length < zero_length_eps.
         Only relevant if use_linear_model_for_zero_length is True.
     :param p_radial_basis_type: The radial basis function type used for p-space.

--- a/equideepdmri/layers/QLengthWeightedPool.py
+++ b/equideepdmri/layers/QLengthWeightedPool.py
@@ -105,7 +105,7 @@ class QLengthWeightedAvgPool(nn.Module, Recomputable):
         """
         Applies the layer to input feature map x.
 
-		:param x: Dim (N x dim_in_out x Q_in x P_z x P_y x P_x)
+        :param x: Dim (N x dim_in_out x Q_in x P_z x P_y x P_x)
 
             - N: batch size
             - dim_in_out: size of the spherical tensor at each point of the input/output feature map.

--- a/equideepdmri/layers/QLengthWeightedPool.py
+++ b/equideepdmri/layers/QLengthWeightedPool.py
@@ -103,7 +103,8 @@ class QLengthWeightedAvgPool(nn.Module, Recomputable):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Applies the layer to input feature map x.
-        :param x: Dim (N x dim_in_out x Q_in x P_z x P_y x P_x)
+
+		:param x: Dim (N x dim_in_out x Q_in x P_z x P_y x P_x)
             - N: batch size
             - dim_in_out: size of the spherical tensor at each point of the input/output feature map.
             - Q_in: size of the input q-space sampling schema.

--- a/equideepdmri/layers/QLengthWeightedPool.py
+++ b/equideepdmri/layers/QLengthWeightedPool.py
@@ -50,12 +50,13 @@ class QLengthWeightedAvgPool(nn.Module, Recomputable):
             Valid options are "gaussian" (default), "cosine", "bessel".
         :param q_radial_basis_params: A (optional) dict of additional parameters for the radial basis function used for q-space.
             Valid keys in this dict are:
+
             - num_layers: Number of layers in the FC applied to the radial basis function.
-                If num_layers = 0 (default) then no FC is applied to the radial basis function.
+              If num_layers = 0 (default) then no FC is applied to the radial basis function.
             - num_units: Number of units (neurons) in each of the layer in the FC applied to the radial basis function.
-                No default, this parameter is required and must be >0 if num_layers > 0.
+              No default, this parameter is required and must be >0 if num_layers > 0.
             - activation_function: activation function used in the FC applied to the radial basis function,
-                valid are "relu" (default) or "swish"
+              valid are "relu" (default) or "swish"
         :param auto_recompute:
             Whether to automatically recompute the kernel in each forward pass.
             By default it is recomputed each time.
@@ -105,12 +106,14 @@ class QLengthWeightedAvgPool(nn.Module, Recomputable):
         Applies the layer to input feature map x.
 
 		:param x: Dim (N x dim_in_out x Q_in x P_z x P_y x P_x)
+
             - N: batch size
             - dim_in_out: size of the spherical tensor at each point of the input/output feature map.
             - Q_in: size of the input q-space sampling schema.
             - P_z, P_y, P_x: p-space size.
         :return: Dim (N x dim_in_out x P_z x P_y x P_x)
-             N: batch size
+
+            - N: batch size
             - dim_in_out: size of the spherical tensor at each point of the input/output feature map.
             - P_z, P_y, P_x: p-space size (same as input).
         """

--- a/equideepdmri/layers/filter/angular_basis_filters.py
+++ b/equideepdmri/layers/filter/angular_basis_filters.py
@@ -56,16 +56,7 @@ class AngularKernelBasis:
         return f'<AngularKernel {self.kernel_type_name} of type {self.kernel.type.multiplicities}>'
 
 
-"""
-Function interface for creation of angular kernels.
 
-:param l_s: Filter orders l for which to create the kernel.
-:param Q_sampling_schema_out: q-sampling schema of output feature map.
-:param Q_sampling_schema_in: q-sampling schema size of input feature map
-:param P_diff_vectors: p-difference vectors. Dim (num_P_diff_vectors x 3)
-:param length_eps: epsilon for considering vector lengths as non-zero if length > length_eps.
-:return 
-"""
 AngularKernelBasisConstructor = Callable[[List[int], Optional[Q_SamplingSchema], Optional[Q_SamplingSchema], torch.Tensor, float], AngularKernelBasis]
 
 
@@ -78,9 +69,14 @@ def TP_AngularKernel(ls: List[int],
                      selection_rule: SelectionRuleOutInterface = selection_rule_out(),
                      normalization='component') -> AngularKernelBasis:
         """
-        :param kernel_1:
-        :param kernel_2:
-        :param l_fitler: which filter orders to produce, default is all possible
+        Function interface for creation of angular kernels.
+
+        :param l_s: Filter orders l for which to create the kernel.
+        :param Q_sampling_schema_out: q-sampling schema of output feature map.
+        :param Q_sampling_schema_in: q-sampling schema size of input feature map
+        :param P_diff_vectors: p-difference vectors. Dim (num_P_diff_vectors x 3)
+        :param length_eps: epsilon for considering vector lengths as non-zero if length > length_eps.
+        :return:
         """
         Q_out = Q_sampling_schema_out.Q if Q_sampling_schema_out is not None else 1
         Q_in = Q_sampling_schema_in.Q if Q_sampling_schema_in is not None else 1

--- a/equideepdmri/layers/filter/angular_basis_filters.py
+++ b/equideepdmri/layers/filter/angular_basis_filters.py
@@ -39,7 +39,7 @@ class AngularKernelBasis:
         """
         Checks that the dimensions of the angular kernel are valid for given values.
 
-		:param Q_out: q-sampling schema size of output feature map.
+        :param Q_out: q-sampling schema size of output feature map.
         :param Q_in: q-sampling schema size of input feature map.
         :param num_P_diff_vectors: number of different p-differences.
         :param kernel_name: Name of the kernel (for debug).

--- a/equideepdmri/layers/filter/angular_basis_filters.py
+++ b/equideepdmri/layers/filter/angular_basis_filters.py
@@ -24,7 +24,6 @@ class AngularKernelBasis:
 
     def __init__(self, kernel: SphericalTensor, kernel_mask: torch.BoolTensor, kernel_type_name: str):
         """
-
         :param kernel: The kernel itself. Dim (num_non_zero_QP x kernel.type.dim)
         :param kernel_mask: Mask that is True for indices where the kernel is non_zero
             (len(kernel_mask.nonzero()) == num_non_zero_QP).
@@ -39,7 +38,8 @@ class AngularKernelBasis:
     def check_validity(self, Q_out: int, Q_in: int, num_P_diff_vectors: int, kernel_name: str = 'kernel'):
         """
         Checks that the dimensions of the angular kernel are valid for given values.
-        :param Q_out: q-sampling schema size of output feature map.
+
+		:param Q_out: q-sampling schema size of output feature map.
         :param Q_in: q-sampling schema size of input feature map.
         :param num_P_diff_vectors: number of different p-differences.
         :param kernel_name: Name of the kernel (for debug).
@@ -58,6 +58,7 @@ class AngularKernelBasis:
 
 """
 Function interface for creation of angular kernels.
+
 :param l_s: Filter orders l for which to create the kernel.
 :param Q_sampling_schema_out: q-sampling schema of output feature map.
 :param Q_sampling_schema_in: q-sampling schema size of input feature map
@@ -77,7 +78,6 @@ def TP_AngularKernel(ls: List[int],
                      selection_rule: SelectionRuleOutInterface = selection_rule_out(),
                      normalization='component') -> AngularKernelBasis:
         """
-
         :param kernel_1:
         :param kernel_2:
         :param l_fitler: which filter orders to produce, default is all possible
@@ -141,8 +141,9 @@ def SH_P_AngularKernel(ls: List[int],
                        length_eps: float,
                        normalization='component') -> AngularKernelBasis:
     """
-    Angular Kernel based on
-    :param ls: List of ranks for which to create the angular kernel
+    Angular Kernel based on.
+
+	:param ls: List of ranks for which to create the angular kernel
         in increasing order
     :param P_diff_vectors: Dim (num_P_diff_vectors, 3)
     :param Q_diff_vectors: Dim (num_Q_diff_vectors, 3)
@@ -179,8 +180,9 @@ def SH_Q_AngularKernel(ls: List[int],
                        normalize_Q_before_diff=True,
                        normalization='component') -> AngularKernelBasis:
     """
-    Angular Kernel based on
-    :param ls: List of ranks for which to create the angular kernel
+    Angular Kernel based on.
+
+	:param ls: List of ranks for which to create the angular kernel
         in increasing order
     :param P_diff_vectors: Dim (num_P_diff_vectors, 3)
     :param Q_diff_vectors: Dim (num_Q_diff_vectors, 3)
@@ -221,8 +223,9 @@ def SH_PQDiff_AngularKernel(ls: List[int],
                             normalize_Q_before_diff=True,
                             normalization='component') -> AngularKernelBasis:
     """
-    Angular Kernel based on
-    :param ls: List of ranks for which to create the angular kernel
+    Angular Kernel based on.
+
+	:param ls: List of ranks for which to create the angular kernel
         in increasing order
     :param P_diff_vectors: Dim (num_P_diff_vectors, 3)
     :param Q_diff_vectors: Dim (num_Q_diff_vectors, 3)

--- a/equideepdmri/layers/filter/angular_basis_filters.py
+++ b/equideepdmri/layers/filter/angular_basis_filters.py
@@ -143,7 +143,7 @@ def SH_P_AngularKernel(ls: List[int],
         in increasing order
     :param P_diff_vectors: Dim (num_P_diff_vectors, 3)
     :param Q_diff_vectors: Dim (num_Q_diff_vectors, 3)
-    :return Dim (num_Q_diff_vectors x num_P_diff_vectors x M_all)
+    :return: Dim (num_Q_diff_vectors x num_P_diff_vectors x M_all)
         where Y.type.dim = sum((2*l + 1) for l in ls)
     """
     Q_out = Q_sampling_schema_out.Q if Q_sampling_schema_out is not None else 1
@@ -182,7 +182,7 @@ def SH_Q_AngularKernel(ls: List[int],
         in increasing order
     :param P_diff_vectors: Dim (num_P_diff_vectors, 3)
     :param Q_diff_vectors: Dim (num_Q_diff_vectors, 3)
-    :return Dim (num_Q_diff_vectors x num_P_diff_vectors x M_all)
+    :return: Dim (num_Q_diff_vectors x num_P_diff_vectors x M_all)
         where M_all = sum((2*l + 1) for l)
     """
     Q_diff_vectors = compute_Q_diff_vectors(Q_sampling_schema_out, Q_sampling_schema_in,
@@ -225,7 +225,7 @@ def SH_PQDiff_AngularKernel(ls: List[int],
         in increasing order
     :param P_diff_vectors: Dim (num_P_diff_vectors, 3)
     :param Q_diff_vectors: Dim (num_Q_diff_vectors, 3)
-    :return Dim (num_Q_diff_vectors x num_P_diff_vectors x M_all)
+    :return: Dim (num_Q_diff_vectors x num_P_diff_vectors x M_all)
         where M_all = sum((2*l + 1) for l)
     """
     Q_diff_vectors = compute_Q_diff_vectors(Q_sampling_schema_out, Q_sampling_schema_in,

--- a/equideepdmri/layers/filter/combined_filter_kernels.py
+++ b/equideepdmri/layers/filter/combined_filter_kernels.py
@@ -26,7 +26,6 @@ class SumKernel(nn.Module):
 
     def forward(self) -> torch.Tensor:
         """
-
         :return: kernel (Q_out x Q_in x num_P_diff_vectors x type_out.dim x type_in.dim)
         """
         # (N_kernels x Q_out x Q_in x num_P_diff_vectors x type_out.dim x type_in.dim)
@@ -45,7 +44,6 @@ class ConcatKernel(nn.Module):
                  P_kernel_size: int,
                  kernel_definitions: List[Tuple[SphericalTensorType, KernelDefinitionInterface]]):
         """
-
         :param type_out:
         :param type_in:
         :param Q_sampling_schema_out:
@@ -80,7 +78,6 @@ class ConcatKernel(nn.Module):
 
     def forward(self) -> torch.Tensor:
         """
-
         :return: kernel (Q_out x Q_in x num_P_diff_vectors x type_out.dim x type_in.dim)
         """
         result_kernel = self.P_diff_vectors.new_zeros((self.Q_out, self.Q_in, self.num_P_diff_vectors, self.type_out.dim, self.type_in.dim))

--- a/equideepdmri/layers/filter/filter_kernel.py
+++ b/equideepdmri/layers/filter/filter_kernel.py
@@ -120,7 +120,6 @@ class Kernel(nn.Module):
 
     def _compute_kernel(self, scalar_kernel_tensor: torch.Tensor) -> torch.Tensor:
         """
-
         :param scalar_kernel_tensor: (Q_out x Q_in x num_P_diff_vectors x scalar_kernel.scalar_basis_size {s})
         :return: (num_non_zero_QP {n} x type_out.dim {o} x type_in.dim {i})
         """
@@ -148,7 +147,6 @@ class Kernel(nn.Module):
 
     def forward(self) -> torch.Tensor:
         """
-
         :return: kernel (Q_out x Q_in x num_P_diff_vectors x type_out.dim x type_in.dim)
         """
         # ----- build the kernel by combining with scalar kernel
@@ -200,7 +198,6 @@ def mul_scalar_angular_kernel(filter_representations: List[Tuple[int, int, int, 
                               filter_dim: int,
                               scalar_kernel_tensor: torch.Tensor, angular_kernel_tensor: torch.Tensor) -> torch.Tensor:
     """
-
     :param scalar_kernel_tensor: (num_non_zero_QP {n} x angular_filter_type.C {c})
         scalar kernel already combined with the weights
     :param angular_kernel_tensor: (num_non_zero_QP {n} x angular_kernel.kernel.type.dim)
@@ -247,7 +244,6 @@ def compute_TP_mixing_matrix_for_filter(type_in: SphericalTensorType, type_out: 
                                         type_angular_filter: SphericalTensorType,
                                         selection_rule: SelectionRuleInterface, normalization: str) -> SparseTensor:
     """
-
     Based on e3nn -> rs._tensor_product_in_out() but adapted to account for type_angular_filter
 
     :param type_in:

--- a/equideepdmri/layers/filter/kernel_builders.py
+++ b/equideepdmri/layers/filter/kernel_builders.py
@@ -178,7 +178,6 @@ def build_kernel_from_definition_name(kernel_definition_name: str, has_Q_in, has
                                       sub_kernel_selection_rule: dict = None,
                                       **kwargs) -> KernelDefinitionInterface:
     """
-
     :param kernel_definition_name:
     :param normalization:
     :param radial_basis_type:

--- a/equideepdmri/layers/filter/radial_basis_filters.py
+++ b/equideepdmri/layers/filter/radial_basis_filters.py
@@ -18,7 +18,6 @@ class RadialKernelBasis(nn.Module):
 
     def forward(self) -> torch.Tensor:
         """
-
         :return: Dim (Q_out x Q_in x num_P_diff_vectors x scalar_basis_size)
         """
         raise NotImplementedError
@@ -45,7 +44,6 @@ class Constant_RadialKernelBasis(RadialKernelBasis):
 
     def forward(self) -> torch.Tensor:
         """
-
         :return: (Q_out x Q_in x num_P_diff_vectors x 1)
         """
         return self.constant_tensor
@@ -77,7 +75,6 @@ class LengthQIn_RadialKernelBasis(RadialKernelBasis):
 
     def forward(self) -> torch.Tensor:
         """
-
         :return: (Q_out x Q_in x num_P_diff_vectors x radial_basis.number_of_basis)
         """
         scalar_values = self.radial_basis(self.lengths_Q_in)  # (Q_in, radial_basis.number_of_basis)
@@ -112,7 +109,6 @@ class LengthQOut_RadialKernelBasis(RadialKernelBasis):
 
     def forward(self) -> torch.Tensor:
         """
-
         :return: (Q_out x Q_in x num_P_diff_vectors x radial_basis.number_of_basis)
         """
         scalar_values = self.radial_basis(self.lengths_Q_out)  # (Q_out, radial_basis.number_of_basis)
@@ -147,7 +143,6 @@ class LengthPDiff_RadialKernelBasis(RadialKernelBasis):
 
     def forward(self) -> torch.Tensor:
         """
-
         :return: (Q_out x Q_in x num_P_diff_vectors x radial_basis.number_of_basis)
         """
         scalar_values = self.radial_basis(self.lengths_P_diff)  # (num_P_diff_vectors, radial_basis.number_of_basis)
@@ -193,6 +188,7 @@ class CombinedRadialKernelBasis(RadialKernelBasis):
     def forward(self) -> torch.Tensor:
         """
         Dim (Q_out x Q_in x num_P_diff_vectors x scalar_basis_size)
+        
         :return:
         """
         scalar_kernel_tensors = [scalar_kernel() for scalar_kernel in self.scalar_kernels]

--- a/equideepdmri/layers/filter/radial_basis_functions.py
+++ b/equideepdmri/layers/filter/radial_basis_functions.py
@@ -81,7 +81,7 @@ class FC(nn.Module):
         """
         Applies the fully connected network to x.
 
-		:param x: Input. Dim (radii_batch_size x dim_in)
+        :param x: Input. Dim (radii_batch_size x dim_in)
         :return: Dim (radii_batch_size x dim_out)
             Note that dim_out = dim_in for num_layers = 0 and dim_out = num_units for num_layers > 0.
         """
@@ -161,8 +161,8 @@ def Cosine_RadialBasis(basis_size: int, max_radius: float,
 
     Note: based on e3nn.radial.CosineBasisModel
 
-    :param basis_size
-    :param max_radius
+    :param basis_size:
+    :param max_radius:
     """
     reference_points = torch.linspace(0, max_radius, steps=basis_size)
     step = reference_points[1] - reference_points[0]
@@ -243,7 +243,8 @@ class Bessel_RadialBasis(RadialBasis):
         \sqrt{\frac{2}{c}} \frac{sin(\frac{n \pi}{c} d)}{d} & 0 \leq x \leq max_radius \\
         0 & otherwise
     \end{cases}
-    c = max_radius (cutoff), n = basis_size, d = distance (in R_{+})"""
+    c = max_radius (cutoff), n = basis_size, d = distance (in R_{+})
+    """
     def __init__(self, basis_size: int, max_radius: float, epsilon=1e-8,
                  num_layers: int = 0, num_units: int = 0, activation_function=None):
         self.model: FC = FC(basis_size,
@@ -259,7 +260,6 @@ class Bessel_RadialBasis(RadialBasis):
 
     def basis(self, x: torch.Tensor) -> torch.Tensor:
         """
-
         :param x: Dim (radii_batch_size)
         :return: Dim (radii_batch_size x basis_size)
         """
@@ -270,7 +270,6 @@ class Bessel_RadialBasis(RadialBasis):
 
     def forward(self, x):
         """
-
         :param x: Dim (radii_batch_size)
         :return: Dim (radii_batch_size x model.dim_out)
         """

--- a/equideepdmri/layers/filter/radial_basis_functions.py
+++ b/equideepdmri/layers/filter/radial_basis_functions.py
@@ -163,7 +163,6 @@ def Cosine_RadialBasis(basis_size: int, max_radius: float,
 
     :param basis_size
     :param max_radius
-
     """
     reference_points = torch.linspace(0, max_radius, steps=basis_size)
     step = reference_points[1] - reference_points[0]

--- a/equideepdmri/layers/filter/radial_basis_functions.py
+++ b/equideepdmri/layers/filter/radial_basis_functions.py
@@ -19,7 +19,6 @@ class RadialBasis(nn.Module):
     """
     def __init__(self, basis_size: int, radial_basis_type_name: str):
         """
-
         :param basis_size: Size of the radial basis (relevant for the output dim when applying this radial basis to radii.
         :param radial_basis_type_name: Name of this type of radial basis, used for debugging only.
         """
@@ -45,7 +44,6 @@ class FC(nn.Module):
     """
     def __init__(self, dim_in: int, num_layers: int = 0, num_units: int = 0, activation_function=None):
         """
-
         :param dim_in: Number of input neurons.
             Note that dim_out = dim_in for num_layers = 0.
         :param num_layers: Number of layers (hidden layers + output layer). If num_layers == 0 then the FC is the identity,
@@ -82,7 +80,8 @@ class FC(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Applies the fully connected network to x.
-        :param x: Input. Dim (radii_batch_size x dim_in)
+
+		:param x: Input. Dim (radii_batch_size x dim_in)
         :return: Dim (radii_batch_size x dim_out)
             Note that dim_out = dim_in for num_layers = 0 and dim_out = num_units for num_layers > 0.
         """
@@ -110,6 +109,7 @@ class FiniteElement_RadialBasis(RadialBasis):
         If num_layers == 0 then basis_size = len(reference_points) else basis_size = num_units.
 
         Note: based on e3nn.radial.FiniteElementFCModel and e3nn.radial.FiniteElementModel
+        
         :param reference_points: the reference points (list of scalars) of Dim (num_reference_points).
             The radial_basis_fn is applied to each of these scalars.
         :param radial_basis_fn: radial basis function applied to each of the reference points.
@@ -197,8 +197,9 @@ def Cosine_RadialBasisConstructor(num_layers: int = 0, num_units: int = 0, activ
 def Gaussian_RadialBasis(basis_size: int, max_radius: float, min_radius=0.,
                          num_layers: int = 0, num_units: int = 0, activation_function='relu'):
     """
-    Note: based on e3nn.radial.GaussianRadialModel
-    :param basis_size:
+    Note: based on e3nn.radial.GaussianRadialModel.
+    
+	:param basis_size:
     :param max_radius:
     :param min_radius:
     :param num_layers:
@@ -222,8 +223,9 @@ def Gaussian_RadialBasis(basis_size: int, max_radius: float, min_radius=0.,
 
 def gaussian_basis_fn(x, sigma):
     """
-    Note: based on e3nn.radial.GaussianRadialModel.basis
-    :param x:
+    Note: based on e3nn.radial.GaussianRadialModel.basis.
+
+	:param x:
     :param sigma:
     :return:
     """

--- a/equideepdmri/layers/filter/utils.py
+++ b/equideepdmri/layers/filter/utils.py
@@ -96,8 +96,9 @@ def tensor_product_out(ls_out: List[int], selection_rule: Callable[[int], List[T
 
 def compute_channel_mapping_matrix(tensor_type: SphericalTensorType) -> torch.Tensor:
     """
-    Note: inspired by rs.map_mul_to_Rs
-    :param tensor_type:
+    Note: inspired by rs.map_mul_to_Rs.
+
+	:param tensor_type:
     :return: Dim (tensor_type.dim x tensor_type.C)
     """
     # (tensor_type.dim x tensor_type.C)
@@ -162,8 +163,9 @@ sh = spherical_harmonics_xyz
 
 def normalize_sh(Y: SphericalTensor, normalization: str = 'norm'):
     """
-    see kernel_mod.py line 20
-    :param Y: spherical tensor. Dim (num_vectors, M_all)
+    see kernel_mod.py line 20.
+
+	:param Y: spherical tensor. Dim (num_vectors, M_all)
     :return:
     """
     # Normalize the spherical harmonics
@@ -178,7 +180,6 @@ def normalize_sh(Y: SphericalTensor, normalization: str = 'norm'):
 
 def normalized_sh(ls: List[int], vectors: torch.Tensor, normalization: str = 'component') -> SphericalTensor:
     """
-
     :param ls:
     :param vectors: (num_vectors, 3)
     :param normalization:

--- a/equideepdmri/layers/filter/utils.py
+++ b/equideepdmri/layers/filter/utils.py
@@ -30,8 +30,8 @@ def tensor_product_in_out(type_in_1: SphericalTensorType, type_out: SphericalTen
                           selection_rule: Callable[[int, int], List[int]], normalization='component') \
         -> Tuple[SphericalTensorType, torch.Tensor]:
     """
-
     Note: based on o3.selection_rule_in_out_sh
+
     :param type_in_1: spherical tensor type of first input to TP
     :param type_out: spherical tensor type of output from TP
     :param selection_rule: selection rule for possible spherical tensor types of second input to TP
@@ -209,7 +209,7 @@ def selection_rule(lmax=None, lfilter=None) -> SelectionRuleInterface:
 def selection_rule_fn(l1: int, l2: int, lmax=None, lfilter=None) -> List[int]:
     """
     selection rule according to the triangle inequality:
-    |l1 - l2| <= l  <= l1 + l2.
+    \|l1 - l2\| <= l  <= l1 + l2.
 
     This inequality is euqivalent to the following inequality system:
     (1) l1 + l2 >= l
@@ -262,9 +262,9 @@ def selection_rule_out_fn(l_out: int, l_diff_to_out_max: int = 1, l_max: int = N
     :param l_max: maximum values for l_1 and l_2 such that l_1 <= l_max and l_2 <= l_max
         default: l_out + l_diff_to_out_max
     :param l_diff_to_out_max: maximum difference between l_1 or l_2 to l_out such that:
-        |l_out - l_1| <= l_diff_to_out_max and |l_out - l_2| <= l_diff_to_out_max
+        \|l_out - l_1\| <= l_diff_to_out_max and \|l_out - l_2\| <= l_diff_to_out_max
         default: 1
-    :param l_in_diff_max: maximum difference between l_1 and l_2 such that: |l_1 - l_2| <= l_in_diff_max
+    :param l_in_diff_max: maximum difference between l_1 and l_2 such that: \|l_1 - l_2\| <= l_in_diff_max
         default: l_out
     :param l_in_filter:
     :param l_pair_filter:

--- a/equideepdmri/layers/layer_builders.py
+++ b/equideepdmri/layers/layer_builders.py
@@ -46,25 +46,27 @@ def build_pq_layer(type_in: Union[SphericalTensorType, List[int]],
         so there is no q_kernel_size.
     :param kernel: Which filter basis to use in the EquivariantPQLayer layer.
         Valid options are:
+
         - "p_space": to use the p-space filter basis
-            using only p-space coordinate offsets in the angular and radial part.
+          using only p-space coordinate offsets in the angular and radial part.
         - "q_space": to use the q-space filter basis
-            using only q-space coordinate offsets in the angular part
-            and q-space coordinates from input and output in the radial part.
+          using only q-space coordinate offsets in the angular part
+          and q-space coordinates from input and output in the radial part.
         - "pq_diff": to use the pq-diff filter basis
-            using difference between p- and q-space coordinate offsets in the angular part
-            and p-space coordinate offsets, q-space coordinates from input and output in the radial part.
+          using difference between p- and q-space coordinate offsets in the angular part
+          and p-space coordinate offsets, q-space coordinates from input and output in the radial part.
         - "pq_TP": to use the TP (tensor product) filter basis
-            using the tensor product of the p- and q-space filters in the angular part
-            and p-space coordinate offsets, q-space coordinates from input and output in the radial part.
+          using the tensor product of the p- and q-space filters in the angular part
+          and p-space coordinate offsets, q-space coordinates from input and output in the radial part.
         - "sum(<filters>)": where <filters> is a ";"-separated list (without spaces) of valid options for kernel_definition,
-            e.g. "sum(pq_diff;p_space)" or "sum(pq_diff;q_space)". This uses the sum of the named basis filters.
+          e.g. "sum(pq_diff;p_space)" or "sum(pq_diff;q_space)". This uses the sum of the named basis filters.
         - "concat(<filters>)" where <filters> is a ";"-separated list (without spaces) of strings "<output_channels>:<filter_type>"
-            where <output_channels> lists the channels of each order where the named filter is to be used
-            (e.g. "[3, 4]" to use it for 3 scalar and 4 vector output channelw) and
-            <filter_type> names a valid kernel_definition to use for these output channels.
-            The number of all concatenated channels needs to math type_out.
-            Example: "concat([3,4]:pq_diff,[5,2,1]:p_space)" which would require type_out = [8,6,1]
+          where <output_channels> lists the channels of each order where the named filter is to be used
+          (e.g. "[3, 4]" to use it for 3 scalar and 4 vector output channelw) and
+          <filter_type> names a valid kernel_definition to use for these output channels.
+          The number of all concatenated channels needs to math type_out.
+          Example: "concat([3,4]:pq_diff,[5,2,1]:p_space)" which would require type_out = [8,6,1]
+
     :param q_sampling_schema_in: The q-sampling schema of input feature map.
         The q-sampling schema may either be given as a Q_SamplingSchema object,
         a Tensor of size (Q_in, 3) or a list of length Q_in (one element for each vector) of lists of size 3 of floats.
@@ -76,11 +78,13 @@ def build_pq_layer(type_in: Union[SphericalTensorType, List[int]],
         Note that Q_out is not explicitly given but derived form the length of this parameter.
         If this is None (default) then the output does not have q-space but only p-space.
     :param non_linearity_config: Dict with the following optional keys:
-         - tensor_non_lin: The nonlinearity to use for channels with l>0 (non-scalar channels).
-                Default (and currently only option) is "gated".
-         - scalar_non_lin: The nonlinearity to use for channles with l=0 (scalar channels).
-                Valid options are "swish" and "relu".
-                Default is "swish".
+
+        - tensor_non_lin: The nonlinearity to use for channels with l>0 (non-scalar channels).
+          Default (and currently only option) is "gated".
+        - scalar_non_lin: The nonlinearity to use for channles with l=0 (scalar channels).
+          Valid options are "swish" and "relu".
+          Default is "swish".
+
     :param use_non_linearity: Whether to use a nonlinearity.
     :param auto_recompute: Whether to automatically recompute the kernel in each forward pass.
         By default it is recomputed each time.
@@ -91,21 +95,25 @@ def build_pq_layer(type_in: Union[SphericalTensorType, List[int]],
         Defaults to using all possible filter orders,
         i.e. all l_filter with  |l_in - l_out | <= l_filter <= l_in + l_out.
         Options are:
+
         - dict with key "lmax" and int value which additionally defines a maximum l_filter.
         - dict with int-pairs as keys and list of ints as values that defines
-            for each pair of l_in and l_out the list of l_filter to use.
-            E.g. {(0,0): [0], (1,1): [0,1], (0,1): [1]}
+          for each pair of l_in and l_out the list of l_filter to use.
+          E.g. {(0,0): [0], (1,1): [0,1], (0,1): [1]}
+
     :param p_radial_basis_type: The radial basis function type used for p-space.
         Valid options are "gaussian" (default), "cosine", "bessel".
         Note that this parameter is ignored if there is no basis filter using p-space.
     :param p_radial_basis_params: A (optional) dict of additional parameters for the radial basis function used for p-space.
         Valid keys in this dict are:
+
         - num_layers: Number of layers in the FC applied to the radial basis function.
-            If num_layers = 0 (default) then no FC is applied to the radial basis function.
+          If num_layers = 0 (default) then no FC is applied to the radial basis function.
         - num_units: Number of units (neurons) in each of the layer in the FC applied to the radial basis function.
-            No default, this parameter is required and must be >0 if num_layers > 0.
+          No default, this parameter is required and must be >0 if num_layers > 0.
         - activation_function: activation function used in the FC applied to the radial basis function,
-            valid are "relu" (default) or "swish"
+          valid are "relu" (default) or "swish"
+
         Note that this parameter is ignored if there is no basis filter using p-space.
     :param q_radial_basis_type: The radial basis function type used for q-space (q-in and q-out).
         Valid options are "gaussian" (default), "cosine", "bessel".
@@ -118,12 +126,14 @@ def build_pq_layer(type_in: Union[SphericalTensorType, List[int]],
         Defaults to q_radial_basis_type.
     :param q_radial_basis_params: A (optional) dict of additional parameters for the radial basis function used for q-space.
         Valid keys in this dict are:
+
         - num_layers: Number of layers in the FC applied to the radial basis function.
-            If num_layers = 0 (default) then no FC is applied to the radial basis function.
+          If num_layers = 0 (default) then no FC is applied to the radial basis function.
         - num_units: Number of units (neurons) in each of the layer in the FC applied to the radial basis function.
-            No default, this parameter is required and must be >0 if num_layers > 0.
+          No default, this parameter is required and must be >0 if num_layers > 0.
         - activation_function: activation function used in the FC applied to the radial basis function,
-            valid are "relu" (default) or "swish"
+          valid are "relu" (default) or "swish"
+
         Note that this parameter is ignored if there is no basis filter using q-space.
     :param q_out_radial_basis_params: A dict of additional parameters for the radial basis function used for q-out (q-space of output feature map).
         See q_radial_basis_params but only for q-out.
@@ -135,17 +145,21 @@ def build_pq_layer(type_in: Union[SphericalTensorType, List[int]],
         Rule defining for the TP filter which pairs of l_p and l_q to use for each l_filter.
         Defaults to "TP\pm 1".
         Options are:
+        
         - dict with string keys: defines some constraints which combinations to use.
-            The following constraint always holds:
-            |l_p - l_q | <= l_filter <= l_p + l_q
-            Additionally constraints can be defined by the following keys in the dict:
-            - "l_diff_to_out_max": Maximum difference between l_p and l_filter as well as l_q and l_filter.
-                Default to 1 (as in "TP\pm 1")
-            - "l_max" (optional): Maximum value for l_p and l_q.
-            - "l_in_diff_max" (optional): Maximum difference between l_p and l_q.
+          The following constraint always holds:
+          |l_p - l_q | <= l_filter <= l_p + l_q
+          Additionally constraints can be defined by the following keys in the dict:
+
+          - "l_diff_to_out_max": Maximum difference between l_p and l_filter as well as l_q and l_filter.
+            Default to 1 (as in "TP\pm 1")
+          - "l_max" (optional): Maximum value for l_p and l_q.
+          - "l_in_diff_max" (optional): Maximum difference between l_p and l_q.
+
         - dict with ints as keys and list of int-pairs as values that defines
-            for each l_filter the used pairs of l_p and l_q.
-            E.g. {0: [(0, 0), (1, 1)], 1: [(0, 1), (1, 0), (1, 1)]}
+          for each l_filter the used pairs of l_p and l_q.
+          E.g. {0: [(0, 0), (1, 1)], 1: [(0, 1), (1, 0), (1, 1)]}
+
         Note that this parameter is ignored if no TP-filter basis is used.
     For additional parameters see EquivariantPQLayer.
     """
@@ -204,11 +218,13 @@ def build_p_layer(type_in: Union[SphericalTensorType, List[int]],
         Note that the kernel always covers the whole q-space (as it is not translationally equivariant),
         so there is no q_kernel_size.
     :param non_linearity_config: Dict with the following optional keys:
-         - tensor_non_lin: The nonlinearity to use for channels with l>0 (non-scalar channels).
-                Default (and currently only option) is "gated".
-         - scalar_non_lin: The nonlinearity to use for channles with l=0 (scalar channels).
-                Valid options are "swish" and "relu".
-                Default is "swish".
+
+        - tensor_non_lin: The nonlinearity to use for channels with l>0 (non-scalar channels).
+          Default (and currently only option) is "gated".
+        - scalar_non_lin: The nonlinearity to use for channles with l=0 (scalar channels).
+          Valid options are "swish" and "relu".
+          Default is "swish".
+    
     :param use_non_linearity: Whether to use a nonlinearity.
     :param auto_recompute: Whether to automatically recompute the kernel in each forward pass.
         By default it is recomputed each time.
@@ -219,21 +235,25 @@ def build_p_layer(type_in: Union[SphericalTensorType, List[int]],
         Defaults to using all possible filter orders,
         i.e. all l_filter with  |l_in - l_out | <= l_filter <= l_in + l_out.
         Options are:
+
         - dict with key "lmax" and int value which additionally defines a maximum l_filter.
         - dict with int-pairs as keys and list of ints as values that defines
-            for each pair of l_in and l_out the list of l_filter to use.
-            E.g. {(0,0): [0], (1,1): [0,1], (0,1): [1]}
+          for each pair of l_in and l_out the list of l_filter to use.
+          E.g. {(0,0): [0], (1,1): [0,1], (0,1): [1]}
+
     :param p_radial_basis_type: The radial basis function type used for p-space.
         Valid options are "gaussian" (default), "cosine", "bessel".
         Note that this parameter is ignored if there is no basis filter using p-space.
     :param p_radial_basis_params: A (optional) dict of additional parameters for the radial basis function used for p-space.
         Valid keys in this dict are:
+
         - num_layers: Number of layers in the FC applied to the radial basis function.
-            If num_layers = 0 (default) then no FC is applied to the radial basis function.
+          If num_layers = 0 (default) then no FC is applied to the radial basis function.
         - num_units: Number of units (neurons) in each of the layer in the FC applied to the radial basis function.
-            No default, this parameter is required and must be >0 if num_layers > 0.
+          No default, this parameter is required and must be >0 if num_layers > 0.
         - activation_function: activation function used in the FC applied to the radial basis function,
-            valid are "relu" (default) or "swish"
+          valid are "relu" (default) or "swish"
+
         Note that this parameter is ignored if there is no basis filter using p-space.
     For additional parameters see EquivariantPLayer.
     """
@@ -266,14 +286,17 @@ def build_q_reduction_layer(type_in: Union[SphericalTensorType, List[int]], q_sa
         Note that Q_in is not explicitly given but derived form the length of this parameter.
         If this is None (default) then the input does not have q-space but only p-space.
     :param reduction: The type of reduction to use. Valid options are:
+
         - length_weighted_average: To use QLengthWeightedAvgPool (global length-weighted avg-pooling over q-space)
-            For additional parameters in param kwargs see QLengthWeightedAvgPool.
+          For additional parameters in param kwargs see QLengthWeightedAvgPool.
         - mean: To use global avg-pooling over q-space.
         - conv: To use an EquivariantPQLayer (and gated nonlinearity) without output q-space.
-            For additional parameters in param kwargs see build_pq_layer
-            (except the params type_out, q_sampling_schema_out).
+          For additional parameters in param kwargs see build_pq_layer
+          (except the params type_out, q_sampling_schema_out).
+
     :param auto_recompute: Whether to automatically recompute the kernels in each forward pass.
     :return (reduction_layer, type_out)
+
         - reduction_layer: The created q-reduction layer (nn.Module)
         - type_out: The spherical tensor type of the output feature map.
     """
@@ -311,6 +334,7 @@ def build_non_linearity(type_out: SphericalTensorType, tensor_non_lin='gated', s
         Valid options are "swish" and "relu".
         Default is "swish".
     :return (type_in, nonlinearity):
+
         - type_in: The expected spherical tensor type of the input feature map.
         - nonlinearity: the nonlinearity (as nn.Module) which accepts the input feature map.
     """

--- a/equideepdmri/layers/layer_builders.py
+++ b/equideepdmri/layers/layer_builders.py
@@ -93,7 +93,7 @@ def build_pq_layer(type_in: Union[SphericalTensorType, List[int]],
     :param kernel_selection_rule: Rule defining which angular filter orders (l_filter) to use
         for a paths form input orders l_in to output orders l_out.
         Defaults to using all possible filter orders,
-        i.e. all l_filter with  |l_in - l_out | <= l_filter <= l_in + l_out.
+        i.e. all l_filter with \|l_in - l_out\| <= l_filter <= l_in + l_out.
         Options are:
 
         - dict with key "lmax" and int value which additionally defines a maximum l_filter.
@@ -148,7 +148,7 @@ def build_pq_layer(type_in: Union[SphericalTensorType, List[int]],
         
         - dict with string keys: defines some constraints which combinations to use.
           The following constraint always holds:
-          |l_p - l_q | <= l_filter <= l_p + l_q
+          \|l_p - l_q\| <= l_filter <= l_p + l_q
           Additionally constraints can be defined by the following keys in the dict:
 
           - "l_diff_to_out_max": Maximum difference between l_p and l_filter as well as l_q and l_filter.
@@ -233,7 +233,7 @@ def build_p_layer(type_in: Union[SphericalTensorType, List[int]],
     :param kernel_selection_rule: Rule defining which angular filter orders (l_filter) to use
         for a paths form input orders l_in to output orders l_out.
         Defaults to using all possible filter orders,
-        i.e. all l_filter with  |l_in - l_out | <= l_filter <= l_in + l_out.
+        i.e. all l_filter with \|l_in - l_out\| <= l_filter <= l_in + l_out.
         Options are:
 
         - dict with key "lmax" and int value which additionally defines a maximum l_filter.
@@ -295,7 +295,7 @@ def build_q_reduction_layer(type_in: Union[SphericalTensorType, List[int]], q_sa
           (except the params type_out, q_sampling_schema_out).
 
     :param auto_recompute: Whether to automatically recompute the kernels in each forward pass.
-    :return (reduction_layer, type_out)
+    :return (reduction_layer, type_out):
 
         - reduction_layer: The created q-reduction layer (nn.Module)
         - type_out: The spherical tensor type of the output feature map.

--- a/equideepdmri/network/VoxelWiseSegmentationNetwork.py
+++ b/equideepdmri/network/VoxelWiseSegmentationNetwork.py
@@ -103,7 +103,7 @@ class VoxelWiseSegmentationNetwork(nn.Module):
             - kernel_selection_rule: Rule defining which angular filter orders (l_filter) to use
               for a paths form input orders l_in to output orders l_out.
               Defaults to using all possible filter orders,
-              i.e. all l_filter with  |l_in - l_out | <= l_filter <= l_in + l_out.
+              i.e. all l_filter with  \|l_in - l_out \| <= l_filter <= l_in + l_out.
               Options are:
 
               - dict with key "lmax" and int value which additionally defines a maximum l_filter.
@@ -158,7 +158,7 @@ class VoxelWiseSegmentationNetwork(nn.Module):
               
               - dict with string keys: defines some constraints which combinations to use.
                 The following constraint always holds:
-                |l_p - l_q | <= l_filter <= l_p + l_q
+                \|l_p - l_q\| <= l_filter <= l_p + l_q
                 Additionally constraints can be defined by the following keys in the dict:
                 
                 - "l_diff_to_out_max": Maximum difference between l_p and l_filter as well as l_q and l_filter.
@@ -178,7 +178,7 @@ class VoxelWiseSegmentationNetwork(nn.Module):
             - kernel_selection_rule: Rule defining which angular filter orders (l_filter) to use
               for a paths form input orders l_in to output orders l_out.
               Defaults to using all possible filter orders,
-              i.e. all l_filter with  |l_in - l_out | <= l_filter <= l_in + l_out.
+              i.e. all l_filter with  \|l_in - l_out\| <= l_filter <= l_in + l_out.
               Options are:
             
               - dict with key "lmax" and int value which additionally defines a maximum l_filter.
@@ -296,7 +296,7 @@ class VoxelWiseSegmentationNetwork(nn.Module):
         """
         Applies the network to the input scan batch.
 
-		:param x: Input feature map. Dim (N x Q_in x P_z x P_y x P_x) with
+        :param x: Input feature map. Dim (N x Q_in x P_z x P_y x P_x) with
             - N: batch size
             - Q_in: size of the input q-space sampling schema.
             - P_z, P_y, P_x: p-space size.

--- a/equideepdmri/network/VoxelWiseSegmentationNetwork.py
+++ b/equideepdmri/network/VoxelWiseSegmentationNetwork.py
@@ -272,7 +272,8 @@ class VoxelWiseSegmentationNetwork(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Applies the network to the input scan batch.
-        :param x: Input feature map. Dim (N x Q_in x P_z x P_y x P_x) with
+
+		:param x: Input feature map. Dim (N x Q_in x P_z x P_y x P_x) with
             - N: batch size
             - Q_in: size of the input q-space sampling schema.
             - P_z, P_y, P_x: p-space size.

--- a/equideepdmri/network/VoxelWiseSegmentationNetwork.py
+++ b/equideepdmri/network/VoxelWiseSegmentationNetwork.py
@@ -70,134 +70,157 @@ class VoxelWiseSegmentationNetwork(nn.Module):
             and the second the number of order-1 (vector) channels and so on.
             For all orders corresponding to out-of-range indices the number of channels is 0.)
             If p_channels = None, then no p-layers are used.
-        :param kernel_sizes The kernel sizes (in p-space) of all pq- and p-layers.
+        :param kernel_sizes: The kernel sizes (in p-space) of all pq- and p-layers.
             If this param is a single int, then the same kernel size is used for all layers.
             Else a list of integers is expected, containing one value (the kernel size)
             for each pq- and each p-layer.
         :param pq_kernel: Dict containing parameters for the kernel of the pq-layers
             (only an entry for the key "kernel" is required):
+
             - kernel (required): Which filter basis to use in this layer.
-                Valid options are:
-                - "p_space": to use the p-space filter basis
-                    using only p-space coordinate offsets in the angular and radial part.
-                - "q_space": to use the q-space filter basis
-                    using only q-space coordinate offsets in the angular part
-                    and q-space coordinates from input and output in the radial part.
-                - "pq_diff": to use the pq-diff filter basis
-                    using difference between p- and q-space coordinate offsets in the angular part
-                    and p-space coordinate offsets, q-space coordinates from input and output in the radial part.
-                - "pq_TP": to use the TP (tensor product) filter basis
-                    using the tensor product of the p- and q-space filters in the angular part
-                    and p-space coordinate offsets, q-space coordinates from input and output in the radial part.
-                - "sum(<filters>)": where <filters> is a ";"-separated list (without spaces) of valid options for kernel_definition,
-                    e.g. "sum(pq_diff;p_space)" or "sum(pq_diff;q_space)". This uses the sum of the named basis filters.
-                - "concat(<filters>)" where <filters> is a ";"-separated list (without spaces) of strings "<output_channels>:<filter_type>"
-                    where <output_channels> lists the channels of each order where the named filter is to be used
-                    (e.g. "[3, 4]" to use it for 3 scalar and 4 vector output channelw) and
-                    <filter_type> names a valid kernel_definition to use for these output channels.
-                    The number of all concatenated channels needs to math type_out.
-                    Example: "concat([3,4]:pq_diff,[5,2,1]:p_space)" which would require type_out = [8,6,1]
+              Valid options are:
+
+              - "p_space": to use the p-space filter basis
+                using only p-space coordinate offsets in the angular and radial part.
+              - "q_space": to use the q-space filter basis
+                using only q-space coordinate offsets in the angular part
+                and q-space coordinates from input and output in the radial part.
+              - "pq_diff": to use the pq-diff filter basis
+                using difference between p- and q-space coordinate offsets in the angular part
+                and p-space coordinate offsets, q-space coordinates from input and output in the radial part.
+              - "pq_TP": to use the TP (tensor product) filter basis
+                using the tensor product of the p- and q-space filters in the angular part
+                and p-space coordinate offsets, q-space coordinates from input and output in the radial part.
+              - "sum(<filters>)": where <filters> is a ";"-separated list (without spaces) of valid options for kernel_definition,
+                e.g. "sum(pq_diff;p_space)" or "sum(pq_diff;q_space)". This uses the sum of the named basis filters.
+              - "concat(<filters>)" where <filters> is a ";"-separated list (without spaces) of strings "<output_channels>:<filter_type>"
+                where <output_channels> lists the channels of each order where the named filter is to be used
+                (e.g. "[3, 4]" to use it for 3 scalar and 4 vector output channelw) and
+                <filter_type> names a valid kernel_definition to use for these output channels.
+                The number of all concatenated channels needs to math type_out.
+                Example: "concat([3,4]:pq_diff,[5,2,1]:p_space)" which would require type_out = [8,6,1]
+
             - kernel_selection_rule: Rule defining which angular filter orders (l_filter) to use
-                for a paths form input orders l_in to output orders l_out.
-                Defaults to using all possible filter orders,
-                i.e. all l_filter with  |l_in - l_out | <= l_filter <= l_in + l_out.
-                Options are:
-                - dict with key "lmax" and int value which additionally defines a maximum l_filter.
-                - dict with int-pairs as keys and list of ints as values that defines
-                    for each pair of l_in and l_out the list of l_filter to use.
-                    E.g. {(0,0): [0], (1,1): [0,1], (0,1): [1]}
+              for a paths form input orders l_in to output orders l_out.
+              Defaults to using all possible filter orders,
+              i.e. all l_filter with  |l_in - l_out | <= l_filter <= l_in + l_out.
+              Options are:
+
+              - dict with key "lmax" and int value which additionally defines a maximum l_filter.
+              - dict with int-pairs as keys and list of ints as values that defines
+                for each pair of l_in and l_out the list of l_filter to use.
+                E.g. {(0,0): [0], (1,1): [0,1], (0,1): [1]}
+
             - p_radial_basis_type: The radial basis function type used for p-space.
-                Valid options are "gaussian" (default), "cosine", "bessel".
-                Note that this parameter is ignored if there is no basis filter using p-space.
+              Valid options are "gaussian" (default), "cosine", "bessel".
+              Note that this parameter is ignored if there is no basis filter using p-space.
             - p_radial_basis_params: A (optional) dict of additional parameters for the radial basis function used for p-space.
-                Valid keys in this dict are:
-                - num_layers: Number of layers in the FC applied to the radial basis function.
-                    If num_layers = 0 (default) then no FC is applied to the radial basis function.
-                - num_units: Number of units (neurons) in each of the layer in the FC applied to the radial basis function.
-                    No default, this parameter is required and must be >0 if num_layers > 0.
-                - activation_function: activation function used in the FC applied to the radial basis function,
-                    valid are "relu" (default) or "swish"
-                Note that this parameter is ignored if there is no basis filter using p-space.
+              Valid keys in this dict are:
+
+              - num_layers: Number of layers in the FC applied to the radial basis function.
+                If num_layers = 0 (default) then no FC is applied to the radial basis function.
+              - num_units: Number of units (neurons) in each of the layer in the FC applied to the radial basis function.
+                No default, this parameter is required and must be >0 if num_layers > 0.
+              - activation_function: activation function used in the FC applied to the radial basis function,
+                valid are "relu" (default) or "swish"
+
+              Note that this parameter is ignored if there is no basis filter using p-space.
             - q_radial_basis_type: The radial basis function type used for q-space (q-in and q-out).
-                Valid options are "gaussian" (default), "cosine", "bessel".
-                Note that this parameter is ignored if there is no basis filter using q-space.
+              Valid options are "gaussian" (default), "cosine", "bessel".
+              Note that this parameter is ignored if there is no basis filter using q-space.
             - q_out_radial_basis_type: The radial basis function type used for q-out (q-space of output feature map).
-                See q_radial_basis_type but only for q-out.
-                Defaults to q_radial_basis_type.
+              See q_radial_basis_type but only for q-out.
+              Defaults to q_radial_basis_type.
             - q_in_radial_basis_type: The radial basis function type used for q-in (q-space of input feature map).
-                See q_radial_basis_type but only for q-in.
-                Defaults to q_radial_basis_type.
+              See q_radial_basis_type but only for q-in.
+              Defaults to q_radial_basis_type.
             - q_radial_basis_params: A (optional) dict of additional parameters for the radial basis function used for q-space.
-                Valid keys in this dict are:
-                - num_layers: Number of layers in the FC applied to the radial basis function.
-                    If num_layers = 0 (default) then no FC is applied to the radial basis function.
-                - num_units: Number of units (neurons) in each of the layer in the FC applied to the radial basis function.
-                    No default, this parameter is required and must be >0 if num_layers > 0.
-                - activation_function: activation function used in the FC applied to the radial basis function,
-                    valid are "relu" (default) or "swish"
-                Note that this parameter is ignored if there is no basis filter using q-space.
+              Valid keys in this dict are:
+
+              - num_layers: Number of layers in the FC applied to the radial basis function.
+                If num_layers = 0 (default) then no FC is applied to the radial basis function.
+              - num_units: Number of units (neurons) in each of the layer in the FC applied to the radial basis function.
+                No default, this parameter is required and must be >0 if num_layers > 0.
+              - activation_function: activation function used in the FC applied to the radial basis function,
+                valid are "relu" (default) or "swish"
+
+              Note that this parameter is ignored if there is no basis filter using q-space.
             - q_out_radial_basis_params: A dict of additional parameters for the radial basis function used for q-out (q-space of output feature map).
-                See q_radial_basis_params but only for q-out.
-                Defaults to q_radial_basis_params.
+              See q_radial_basis_params but only for q-out.
+              Defaults to q_radial_basis_params.
             - q_in_radial_basis_params: A dict of additional parameters for the radial basis function used for q-in (q-space of input feature map).
-                See q_radial_basis_params but only for q-in.
-                Defaults to q_radial_basis_params.
+              See q_radial_basis_params but only for q-in.
+              Defaults to q_radial_basis_params.
             - sub_kernel_selection_rule:
-                Rule defining for the TP filter which pairs of l_p and l_q to use for each l_filter.
-                Defaults to "TP\pm 1".
-                Options are:
-                - dict with string keys: defines some constraints which combinations to use.
-                    The following constraint always holds:
-                    |l_p - l_q | <= l_filter <= l_p + l_q
-                    Additionally constraints can be defined by the following keys in the dict:
-                    - "l_diff_to_out_max": Maximum difference between l_p and l_filter as well as l_q and l_filter.
-                        Default to 1 (as in "TP\pm 1")
-                    - "l_max" (optional): Maximum value for l_p and l_q.
-                    - "l_in_diff_max" (optional): Maximum difference between l_p and l_q.
-                - dict with ints as keys and list of int-pairs as values that defines
-                    for each l_filter the used pairs of l_p and l_q.
-                    E.g. {0: [(0, 0), (1, 1)], 1: [(0, 1), (1, 0), (1, 1)]}
-                Note that this parameter is ignored if no TP-filter basis is used.
+              Rule defining for the TP filter which pairs of l_p and l_q to use for each l_filter.
+              Defaults to "TP\pm 1".
+              Options are:
+              
+              - dict with string keys: defines some constraints which combinations to use.
+                The following constraint always holds:
+                |l_p - l_q | <= l_filter <= l_p + l_q
+                Additionally constraints can be defined by the following keys in the dict:
+                
+                - "l_diff_to_out_max": Maximum difference between l_p and l_filter as well as l_q and l_filter.
+                  Default to 1 (as in "TP\pm 1")
+                - "l_max" (optional): Maximum value for l_p and l_q.
+                - "l_in_diff_max" (optional): Maximum difference between l_p and l_q.
+              
+              - dict with ints as keys and list of int-pairs as values that defines
+                for each l_filter the used pairs of l_p and l_q.
+                E.g. {0: [(0, 0), (1, 1)], 1: [(0, 1), (1, 0), (1, 1)]}
+              
+              Note that this parameter is ignored if no TP-filter basis is used.
 
             For more params see layers.EquivariantPQLayer
         :param p_kernel: Dict containing parameters for the kernel of the pq-layers (optional):
+            
             - kernel_selection_rule: Rule defining which angular filter orders (l_filter) to use
-                for a paths form input orders l_in to output orders l_out.
-                Defaults to using all possible filter orders,
-                i.e. all l_filter with  |l_in - l_out | <= l_filter <= l_in + l_out.
-                Options are:
-                - dict with key "lmax" and int value which additionally defines a maximum l_filter.
-                - dict with int-pairs as keys and list of ints as values that defines
-                    for each pair of l_in and l_out the list of l_filter to use.
-                    E.g. {(0,0): [0], (1,1): [0,1], (0,1): [1]}
+              for a paths form input orders l_in to output orders l_out.
+              Defaults to using all possible filter orders,
+              i.e. all l_filter with  |l_in - l_out | <= l_filter <= l_in + l_out.
+              Options are:
+            
+              - dict with key "lmax" and int value which additionally defines a maximum l_filter.
+              - dict with int-pairs as keys and list of ints as values that defines
+                for each pair of l_in and l_out the list of l_filter to use.
+                E.g. {(0,0): [0], (1,1): [0,1], (0,1): [1]}
+            
             - p_radial_basis_type: The radial basis function type used for p-space.
-                Valid options are "gaussian" (default), "cosine", "bessel".
+              Valid options are "gaussian" (default), "cosine", "bessel".
             - p_radial_basis_params: A (optional) dict of additional parameters for the radial basis function used for p-space.
-                Valid keys in this dict are:
-                - num_layers: Number of layers in the FC applied to the radial basis function.
-                    If num_layers = 0 (default) then no FC is applied to the radial basis function.
-                - num_units: Number of units (neurons) in each of the layer in the FC applied to the radial basis function.
-                    No default, this parameter is required and must be >0 if num_layers > 0.
-                - activation_function: activation function used in the FC applied to the radial basis function,
-                    valid are "relu" (default) or "swish"
+              Valid keys in this dict are:
+            
+              - num_layers: Number of layers in the FC applied to the radial basis function.
+                If num_layers = 0 (default) then no FC is applied to the radial basis function.
+              - num_units: Number of units (neurons) in each of the layer in the FC applied to the radial basis function.
+                No default, this parameter is required and must be >0 if num_layers > 0.
+              - activation_function: activation function used in the FC applied to the radial basis function,
+                valid are "relu" (default) or "swish"
+        
         :param non_linearity: Dict with the following optional keys:
-             - tensor_non_lin: The nonlinearity to use for channels with l>0 (non-scalar channels).
-                    Default (and currently only option) is "gated".
-             - scalar_non_lin: The nonlinearity to use for channles with l=0 (scalar channels).
-                    Valid options are "swish" and "relu".
-                    Default is "swish".
+        
+            - tensor_non_lin: The nonlinearity to use for channels with l>0 (non-scalar channels).
+              Default (and currently only option) is "gated".
+            - scalar_non_lin: The nonlinearity to use for channles with l=0 (scalar channels).
+              Valid options are "swish" and "relu".
+              Default is "swish".
+        
         :param q_sampling_schemas: List of output q_sampling schemes of the pq-layers
             or None if q_sampling_schema_in should be used in the output of all pq-layers.
             If not None, then the length must equal the length of pq_channels.
         :param q_reduction: Dict configuring the q-reduction layer with the following keys:
+            
             - reduction: The type of reduction to use. Valid options are:
-                - length_weighted_average: To use QLengthWeightedAvgPool (global length-weighted avg-pooling over q-space)
-                    For additional keys in the dict see QLengthWeightedAvgPool
-                    (except the params type_in, q_sampling_schema_in, auto_recompute).
-                - mean: To use global avg-pooling over q-space.
-                - conv: To use an EquivariantPQLayer (and gated nonlinearity) without output q-space.
-                    For additional keys in the dict see build_pq_layer
-                    (except the params type_in, type_out, q_sampling_schema_in, q_sampling_schema_out, auto_recompute).
+            
+              - length_weighted_average: To use QLengthWeightedAvgPool (global length-weighted avg-pooling over q-space)
+                For additional keys in the dict see QLengthWeightedAvgPool
+                (except the params type_in, q_sampling_schema_in, auto_recompute).
+              - mean: To use global avg-pooling over q-space.
+              - conv: To use an EquivariantPQLayer (and gated nonlinearity) without output q-space.
+                For additional keys in the dict see build_pq_layer
+                (except the params type_in, type_out, q_sampling_schema_in, q_sampling_schema_out, auto_recompute).
+        
         :param auto_recompute: Whether to automatically recompute the kernels in each forward pass.
             By default it is recomputed each time.
             If this parameter is set to False, it is not recomputed and the method recompute() needs to be called

--- a/equideepdmri/utils/q_space.py
+++ b/equideepdmri/utils/q_space.py
@@ -14,9 +14,9 @@ class Q_SamplingSchema:
         :param b0_eps: eps value such that all q-vectors with length <b0_eps are treated as b=0.
             Only used if b0_mask = None.
         :param normalize: Whether to normalize the q-length to max=1
-        :radial_basis_size: Size of the radial basis for this sampling scheme, default is number of different q-lengths
+        :param radial_basis_size: Size of the radial basis for this sampling scheme, default is number of different q-lengths
             (max Q) or 0 if Q=1.
-        :radial_basis_eps: Minimum difference between q-length to consider them as different.
+        :param radial_basis_eps: Minimum difference between q-length to consider them as different.
         """
         if not isinstance(q_vectors, torch.Tensor):
             q_vectors = torch.tensor(q_vectors)

--- a/equideepdmri/utils/q_space.py
+++ b/equideepdmri/utils/q_space.py
@@ -115,7 +115,8 @@ class Q_SamplingSchema:
     def extract_b0_channels(self, tensor_field: torch.Tensor) -> torch.Tensor:
         """
         Extracts only the Q channels with b=0 (based on self) of the given tensor field.
-        :param tensor_field: (N x dim_in x Q x P_z x P_y x P_x)
+
+		:param tensor_field: (N x dim_in x Q x P_z x P_y x P_x)
         :return: (N x dim_in x num_b0_channels x P_z x P_y x P_x)
         """
         assert tensor_field.ndim == 6
@@ -147,6 +148,7 @@ class Q_SamplingSchema:
         """
         Combines all b=0 channels to a single b=0 channel, leaves the other channels unchanged.
         The combined b=0 channel will be the first channel.
+        
         :param tensor_field: (N x dim_in x Q x P_z x P_y x P_x)
         :param combination_fn: Function to combine the different b=0 channels. Default: mean
         :param kwargs:

--- a/equideepdmri/utils/q_space.py
+++ b/equideepdmri/utils/q_space.py
@@ -82,7 +82,6 @@ class Q_SamplingSchema:
     @property
     def q_lengths(self) -> torch.Tensor:
         """
-
         :return: Dim (Q)
         """
         return torch.norm(self.q_vectors, p=2, dim=1)
@@ -115,8 +114,8 @@ class Q_SamplingSchema:
     def extract_b0_channels(self, tensor_field: torch.Tensor) -> torch.Tensor:
         """
         Extracts only the Q channels with b=0 (based on self) of the given tensor field.
-
-		:param tensor_field: (N x dim_in x Q x P_z x P_y x P_x)
+        
+        :param tensor_field: (N x dim_in x Q x P_z x P_y x P_x)
         :return: (N x dim_in x num_b0_channels x P_z x P_y x P_x)
         """
         assert tensor_field.ndim == 6

--- a/equideepdmri/utils/spherical_tensor.py
+++ b/equideepdmri/utils/spherical_tensor.py
@@ -52,6 +52,7 @@ class SphericalTensorType:
     def C(self) -> int:
         """
         Number of channels for all l (sum of all C_l).
+        
         :return:
         """
         return sum(C_l for l, C_l in enumerate(self.multiplicities))
@@ -59,7 +60,8 @@ class SphericalTensorType:
     def C_l(self, l) -> int:
         """
         Number of channels for order l.
-        :param l:
+
+		:param l:
         :return:
         """
         return self.multiplicities[l] if l <= self.l_max else 0
@@ -67,7 +69,8 @@ class SphericalTensorType:
     def slice_l(self, l: int) -> slice:
         """
         Slice of an spherical tensor representing the data of all channels of a given order l.
-        :param l:
+
+		:param l:
         :return: Slice of length C_l*(2l+1)
         """
         start_index = self.order_start_indices[l]
@@ -77,7 +80,8 @@ class SphericalTensorType:
     def slice_c_l(self, l: int, c_l: int) -> slice:
         """
         Slice of an spherical tensor representing the data of channel c_l of given order l.
-        :param l:
+
+		:param l:
         :param c_l: 0-based channel index (within the given order l)
         :return: Slice of length (2l+1)
         """
@@ -148,7 +152,6 @@ class SphericalTensor:
 
     def __init__(self, data: torch.Tensor, type: SphericalTensorType, representation_dim=-1):
         """
-
         :param data: Dim (... x type.dim)
         :param type:
         :param representation_dim: index of the dimension that contains the spherical tensor representation
@@ -178,7 +181,6 @@ class SphericalTensor:
 
     def apply_operator(self, operator_matrix: torch.Tensor, batch_wise=False) -> 'SphericalTensor':
         """
-
         :param operator_matrix: ([N_op x ]type.dim x type.dim)
         :param batch_wise
             If True the first dimension of this is interpreted as batch dimension (has to be same as N_op) and the operator

--- a/equideepdmri/utils/spherical_tensor.py
+++ b/equideepdmri/utils/spherical_tensor.py
@@ -61,7 +61,7 @@ class SphericalTensorType:
         """
         Number of channels for order l.
 
-		:param l:
+        :param l:
         :return:
         """
         return self.multiplicities[l] if l <= self.l_max else 0
@@ -70,7 +70,7 @@ class SphericalTensorType:
         """
         Slice of an spherical tensor representing the data of all channels of a given order l.
 
-		:param l:
+        :param l:
         :return: Slice of length C_l*(2l+1)
         """
         start_index = self.order_start_indices[l]
@@ -81,7 +81,7 @@ class SphericalTensorType:
         """
         Slice of an spherical tensor representing the data of channel c_l of given order l.
 
-		:param l:
+        :param l:
         :param c_l: 0-based channel index (within the given order l)
         :return: Slice of length (2l+1)
         """


### PR DESCRIPTION
This PR fixes most warnings and syntax mistakes I got when trying to generate the docs with Sphinx. There are still some things that don't generate correctly, like the math tex in some of the filters.

If you like this I can submit a new PR with a sphinx generator, which you can use to  host your docs on GitHub Pages or similar.

Anyway, here are the docs I've generated. They are a little rough around the edges (that's mostly due to the template I've used. [This theme](https://sphinx-themes.org/sample-sites/sphinx-book-theme/))
![image](https://user-images.githubusercontent.com/10438686/120801051-f7befd80-c540-11eb-99e7-a2d5d82249fd.png)

[Download equideepdmri_docs.zip](https://github.com/philip-mueller/equivariant-deep-dmri/files/6598415/equideepdmri_docs.zip)